### PR TITLE
Display avg review rating on shelter show page

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,4 +4,8 @@ class Review < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :rating
   validates_presence_of :content
+
+  def has_image 
+    optional_picture != nil
+  end
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -7,4 +7,8 @@ class Shelter < ApplicationRecord
   validates_presence_of :city
   validates_presence_of :state
   validates_presence_of :zip
+
+  def avg_rating
+    reviews.average(:rating)
+  end  
 end

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -12,12 +12,15 @@
 </div>
 
 <h2>Reviews:</h2>
+<h5>Average rating: <%= @shelter.avg_rating %></h5>
 <% @shelter.reviews.each do |review| %>
   <div class="content-card">
     <h3><%= review.title %></h3>
     <p>Rating: <%= review.rating %></p>
     <p>Content: <%= review.content %></p>
-    <%= image_tag review.optional_picture, class: "image"%>
+    <% if review.optional_picture %>
+      <%= image_tag review.optional_picture, class: "image"%>
+    <% end %>
     <%= link_to "Edit Review", "/shelters/#{@shelter.id}/reviews/#{review.id}/edit" %><br>
     <%= link_to "Delete Review", "/shelters/#{@shelter.id}/reviews/#{review.id}", method: :delete, data: {confirm: "Are you sure you want to delete this review?"} %>
   </div>

--- a/app/views/shelters/show.html.erb
+++ b/app/views/shelters/show.html.erb
@@ -12,7 +12,7 @@
 </div>
 
 <h2>Reviews:</h2>
-<h5>Average rating: <%= @shelter.avg_rating %></h5>
+<h4>Average rating: <%= @shelter.avg_rating %></h4>
 <% @shelter.reviews.each do |review| %>
   <div class="content-card">
     <h3><%= review.title %></h3>

--- a/spec/features/shelters/show_spec.rb
+++ b/spec/features/shelters/show_spec.rb
@@ -69,8 +69,21 @@ RSpec.describe "show shelter by id page", type: :feature do
     expect(page).to have_css("img[src*=heart-4]")
   end
 
-  it "can see a link to add a new review" do
+  it "can still render a review without an image" do
+    @review_2 = @shelter_1.reviews.create!(
+                                            title: "meh",
+                                            rating: 2,
+                                            content: "it was weird."
+                                          )
 
+    visit "/shelters/#{@shelter_1.id}"
+
+    expect(page).to have_content(@review_2.title)
+    expect(page).to have_content(@review_2.rating)
+    expect(page).to have_content(@review_2.content)
+  end
+
+  it "can see a link to add a new review" do
     visit "/shelters/#{@shelter_1.id}"
 
     expect(page).to have_link(href: "/shelters/#{@shelter_1.id}/reviews/new")
@@ -99,11 +112,11 @@ RSpec.describe "show shelter by id page", type: :feature do
 
   it "can delete a review" do
     @review = @shelter_1.reviews.create!(
-      title: "Mountains of Love <3!",
-      rating: 5,
-      content: "Super clean, well-facilitated, and healthy pups.",
-      optional_picture: "https://static.boredpanda.com/blog/wp-content/uuuploads/tuna-funny-dog-tunameltsmyheart/tuna-funny-dog-tunameltsmyheart-4.jpg",
-    )
+                                          title: "Mountains of Love <3!",
+                                          rating: 5,
+                                          content: "Super clean, well-facilitated, and healthy pups.",
+                                          optional_picture: "https://static.boredpanda.com/blog/wp-content/uuuploads/tuna-funny-dog-tunameltsmyheart/tuna-funny-dog-tunameltsmyheart-4.jpg",
+                                        )
 
     visit "/shelters/#{@shelter_1.id}"
     expect(page).to have_link("Delete Review")
@@ -113,5 +126,24 @@ RSpec.describe "show shelter by id page", type: :feature do
     expect(current_path).to eq("/shelters/#{@shelter_1.id}")
     expect(page).to_not have_content(@review.title)
     expect(page).to_not have_link("Delete Review")
+  end
+
+  it "can see average review rating" do
+    @review_1 = @shelter_1.reviews.create!(
+                                          title: "Mountains of Love! <3",
+                                          rating: 5,
+                                          content: "Super clean, well-facilitated, and healthy pups.", 
+                                          optional_picture: "https://static.boredpanda.com/blog/wp-content/uuuploads/tuna-funny-dog-tunameltsmyheart/tuna-funny-dog-tunameltsmyheart-4.jpg"
+                                        )
+
+    @review_2 = @shelter_1.reviews.create!(
+                                          title: "meh",
+                                          rating: 2,
+                                          content: "it was weird."
+                                        )
+    
+    visit "/shelters/#{@shelter_1.id}"
+
+    expect(page).to have_content("Average rating: #{@shelter_1.avg_rating}")
   end
 end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -7,21 +7,29 @@ describe Review, type: :model do
 
   describe 'instance methods' do 
     before :each do 
-      @review_1 = @shelter.reviews.create!(
+      @shelter_1 = Shelter.create!(
+                                    name: "Rocky Mountain Puppy Rescue",
+                                    address: "10021 E Iliff Ave",
+                                    city: "Aurora",
+                                    state: "CO",
+                                    zip: "80247"
+                                  )
+
+      @review_1 = @shelter_1.reviews.create!(
                                             title: "Mountains of Love! <3",
                                             rating: 5,
                                             content: "Super clean, well-facilitated, and healthy pups.", 
                                             optional_picture: "https://static.boredpanda.com/blog/wp-content/uuuploads/tuna-funny-dog-tunameltsmyheart/tuna-funny-dog-tunameltsmyheart-4.jpg"
                                           )
 
-      @review_2 = @shelter.reviews.create!(
+      @review_2 = @shelter_1.reviews.create!(
                                             title: "meh",
                                             rating: 2,
                                             content: "it was weird."
                                           )
     end
 
-    describe 'it can determine if review has an image or not' do
+    it 'can determine if review has an image or not' do
       expect(@review_1.has_image).to eq(true)
       expect(@review_2.has_image).to eq(false)
     end

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -4,4 +4,26 @@ describe Review, type: :model do
   describe 'relationships' do
     it { should belong_to :shelter }
   end
+
+  describe 'instance methods' do 
+    before :each do 
+      @review_1 = @shelter.reviews.create!(
+                                            title: "Mountains of Love! <3",
+                                            rating: 5,
+                                            content: "Super clean, well-facilitated, and healthy pups.", 
+                                            optional_picture: "https://static.boredpanda.com/blog/wp-content/uuuploads/tuna-funny-dog-tunameltsmyheart/tuna-funny-dog-tunameltsmyheart-4.jpg"
+                                          )
+
+      @review_2 = @shelter.reviews.create!(
+                                            title: "meh",
+                                            rating: 2,
+                                            content: "it was weird."
+                                          )
+    end
+
+    describe 'it can determine if review has an image or not' do
+      expect(@review_1.has_image).to eq(true)
+      expect(@review_2.has_image).to eq(false)
+    end
+  end
 end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -13,4 +13,34 @@ describe Shelter, type: :model do
     it { should validate_presence_of :state }
     it { should validate_presence_of :zip }
   end
+
+  describe "class methods" do
+    before :each do 
+      @shelter = Shelter.create!(
+                                  name: "Rocky Mountain Puppy Rescue",
+                                  address: "10021 E Iliff Ave",
+                                  city: "Aurora",
+                                  state: "CO",
+                                  zip: "80247"
+                                )
+
+      @review_1 = @shelter.reviews.create!(
+                                  title: "Mountains of Love! <3",
+                                  rating: 5,
+                                  content: "Super clean, well-facilitated, and healthy pups.", 
+                                  optional_picture: "https://static.boredpanda.com/blog/wp-content/uuuploads/tuna-funny-dog-tunameltsmyheart/tuna-funny-dog-tunameltsmyheart-4.jpg"
+                                )
+
+      @review_2 = @shelter.reviews.create!(
+                                  title: "meh",
+                                  rating: 2,
+                                  content: "it was weird."
+                                )
+
+    end
+
+    it "can get average review rating for a shelter" do
+      expect(@shelter.avg_rating).to eq(3.5)
+    end
+  end
 end


### PR DESCRIPTION
Part of story #30 

Created tests and functionality below: 
- Display the average rating for a shelter on shelter show page
- Make sure a review will still render without the optional image
- Model methods for getting avg review for a shelter and for determining if review has an image or not
